### PR TITLE
Add basic backend unit tests

### DIFF
--- a/backend/cmd/executor/main_test.go
+++ b/backend/cmd/executor/main_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+    "context"
+    "testing"
+
+    pb "github.com/chiyonn/swarmyard/api/proto/tradeexecutor"
+)
+
+func TestExecutorServerPlaceOrder(t *testing.T) {
+    s := &ExecutorServer{}
+    req := &pb.OrderRequest{BotId: "bot", Pair: "USD/JPY", Amount: 1, Side: pb.Side_BUY}
+    resp, err := s.PlaceOrder(context.Background(), req)
+    if err != nil {
+        t.Fatalf("PlaceOrder returned error: %v", err)
+    }
+    if resp.Status != pb.OrderStatus_SUCCESS {
+        t.Errorf("expected SUCCESS got %v", resp.Status)
+    }
+    if resp.OrderId == "" {
+        t.Errorf("expected non-empty order id")
+    }
+}
+
+func TestExecutorServerPauseResume(t *testing.T) {
+    s := &ExecutorServer{}
+    botReq := &pb.BotRequest{BotId: "bot"}
+    pause, err := s.PauseBot(context.Background(), botReq)
+    if err != nil {
+        t.Fatalf("PauseBot error: %v", err)
+    }
+    if pause.Status != "paused" {
+        t.Errorf("expected paused got %s", pause.Status)
+    }
+    resume, err := s.ResumeBot(context.Background(), botReq)
+    if err != nil {
+        t.Fatalf("ResumeBot error: %v", err)
+    }
+    if resume.Status != "resumed" {
+        t.Errorf("expected resumed got %s", resume.Status)
+    }
+}
+

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+    "os"
+    "testing"
+)
+
+func TestLoad(t *testing.T) {
+    os.Setenv("GRPC_ADDRESS", ":12345")
+    os.Setenv("MODE", "DEMO")
+    os.Setenv("BOT_ID", "test-bot")
+    defer os.Unsetenv("GRPC_ADDRESS")
+    defer os.Unsetenv("MODE")
+    defer os.Unsetenv("BOT_ID")
+
+    cfg, err := Load()
+    if err != nil {
+        t.Fatalf("Load returned error: %v", err)
+    }
+    if cfg.GRPCAddress != ":12345" {
+        t.Errorf("GRPCAddress expected :12345 got %s", cfg.GRPCAddress)
+    }
+    if cfg.Mode != "DEMO" {
+        t.Errorf("Mode expected DEMO got %s", cfg.Mode)
+    }
+    if cfg.BotID != "test-bot" {
+        t.Errorf("BotID expected test-bot got %s", cfg.BotID)
+    }
+}

--- a/backend/internal/strategy/sma_test.go
+++ b/backend/internal/strategy/sma_test.go
@@ -1,0 +1,21 @@
+package strategy
+
+import "testing"
+
+func TestSMAStrategyDecide(t *testing.T) {
+    cases := []struct {
+        price    float64
+        expected string
+    }{
+        {140.10, "BUY"},
+        {140.90, "SELL"},
+        {140.50, "HOLD"},
+    }
+
+    s := &SMAStrategy{}
+    for _, c := range cases {
+        if got := s.Decide(c.price); got != c.expected {
+            t.Errorf("price %.2f expected %s got %s", c.price, c.expected, got)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for config loading
- add tests for SMA strategy logic
- add tests for executor server handlers

## Testing
- `go test ./...` *(fails: unable to download Go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6844cadfb80483328977024b7488a6ba